### PR TITLE
Add font patch option

### DIFF
--- a/SenLib/Sen1/FileFixes/ed8_exe.cs
+++ b/SenLib/Sen1/FileFixes/ed8_exe.cs
@@ -17,6 +17,7 @@ namespace SenLib.Sen1.FileFixes {
 		bool DisableMouseCapture;
 		bool DisablePauseOnFocusLoss;
 		bool FixArtsSupport;
+		bool Force0Kerning;
 
 		public ed8_exe(
 			bool jp,
@@ -27,7 +28,8 @@ namespace SenLib.Sen1.FileFixes {
 			bool correctLanguageVoiceTables,
 			bool disableMouseCapture,
 			bool disablePauseOnFocusLoss,
-			bool fixArtsSupport
+			bool fixArtsSupport,
+			bool force0Kerning
 		) {
 			IsJp = jp;
 			RemoveTurboSkip = removeTurboSkip;
@@ -38,6 +40,7 @@ namespace SenLib.Sen1.FileFixes {
 			DisableMouseCapture = disableMouseCapture;
 			DisablePauseOnFocusLoss = disablePauseOnFocusLoss;
 			FixArtsSupport = fixArtsSupport;
+			Force0Kerning = force0Kerning;
 		}
 
 		public string GetDescription() {
@@ -87,6 +90,9 @@ namespace SenLib.Sen1.FileFixes {
 			}
 			if (FixArtsSupport) {
 				Sen1ExecutablePatches.PatchFixArtsSupportCutin(ms, PatchInfo);
+			}
+			if (!IsJp && Force0Kerning) {
+				Sen1ExecutablePatches.PatchForce0Kerning(ms, PatchInfo);
 			}
 
 			if (IsJp) {

--- a/SenLib/Sen1/Sen1ExecutablePatchState.cs
+++ b/SenLib/Sen1/Sen1ExecutablePatchState.cs
@@ -31,6 +31,9 @@ namespace SenLib.Sen1 {
 		// address of conditional jump statement for not displaying the R2 option in the settings when turbo is enabled
 		public long AddressJumpR2NotebookSettings { get; private set; }
 
+		// address of a conditional that jumps over setting the font kerning value to 0
+		public long AddressForce0Kerning { get; private set; }
+
 		// address of extra character in the middle of texture ID string of Thor MQ, for the HQ texture pack
 		public long RomAddressThorMasterQuartzTextureIdTypo { get; private set; }
 
@@ -59,6 +62,7 @@ namespace SenLib.Sen1 {
 				AddressJumpBattleResultsAutoSkip = 0x4f224f;
 				AddressJumpR2NotebookOpen = 0x5b812f;
 				AddressJumpR2NotebookSettings = 0x6dfaf0;
+				AddressForce0Kerning = 0x5a0631;
 				RomAddressThorMasterQuartzTextureIdTypo = 0x73adba;
 				PushAddressVersionString = 0x69042d;
 			}

--- a/SenLib/Sen1/Sen1ExecutablePatches.cs
+++ b/SenLib/Sen1/Sen1ExecutablePatches.cs
@@ -69,6 +69,12 @@ namespace SenLib.Sen1 {
 			binary.WriteUInt8(0x90); // nop
 		}
 
+		public static void PatchForce0Kerning(Stream binary, Sen1ExecutablePatchState patchInfo) {
+			binary.Position = (long)patchInfo.Mapper.MapRamToRom((ulong)patchInfo.AddressForce0Kerning);
+			binary.WriteUInt8(0x90); // nop
+			binary.WriteUInt8(0x90); // nop
+		}
+
 		public static void PatchThorMasterQuartzString(Stream binary, Sen1ExecutablePatchState patchInfo) {
 			binary.Position = patchInfo.RomAddressThorMasterQuartzTextureIdTypo;
 			long p = binary.Position;

--- a/SenLib/Sen1/Sen1Mods.cs
+++ b/SenLib/Sen1/Sen1Mods.cs
@@ -15,7 +15,8 @@ namespace SenLib.Sen1 {
 			bool correctLanguageVoiceTables = false,
 			bool disableMouseCapture = false,
 			bool disablePauseOnFocusLoss = false,
-			bool fixArtsSupport = false
+			bool fixArtsSupport = false,
+			bool force0Kerning = false
 		) {
 			var f = new List<FileMod>();
 			for (int i = 0; i < 2; ++i) {
@@ -28,7 +29,8 @@ namespace SenLib.Sen1 {
 					correctLanguageVoiceTables: correctLanguageVoiceTables,
 					disableMouseCapture: disableMouseCapture,
 					disablePauseOnFocusLoss: disablePauseOnFocusLoss,
-					fixArtsSupport: fixArtsSupport
+					fixArtsSupport: fixArtsSupport,
+					force0Kerning: force0Kerning
 				));
 			}
 			return f;

--- a/SenLib/Sen2/FileFixes/ed8_2_exe.cs
+++ b/SenLib/Sen2/FileFixes/ed8_2_exe.cs
@@ -15,6 +15,7 @@ namespace SenLib.Sen2.FileFixes {
 		bool DisablePauseOnFocusLoss;
 		bool FixControllerMapping;
 		bool FixArtsSupport;
+		bool Force0Kerning;
 
 		public ed8_2_exe(
 			Sen2Version version,
@@ -27,7 +28,8 @@ namespace SenLib.Sen2.FileFixes {
 			bool disableMouseCapture,
 			bool disablePauseOnFocusLoss,
 			bool fixControllerMapping,
-			bool fixArtsSupport
+			bool fixArtsSupport,
+			bool force0Kerning
 		) {
 			Version = version;
 			IsJp = jp;
@@ -40,6 +42,7 @@ namespace SenLib.Sen2.FileFixes {
 			DisablePauseOnFocusLoss = disablePauseOnFocusLoss;
 			FixControllerMapping = fixControllerMapping;
 			FixArtsSupport = fixArtsSupport;
+			Force0Kerning = force0Kerning;
 		}
 
 		public string GetDescription() {
@@ -109,6 +112,9 @@ namespace SenLib.Sen2.FileFixes {
 			}
 			if (FixArtsSupport) {
 				Sen2ExecutablePatches.PatchFixArtsSupportCutin(ms, state);
+			}
+			if (!IsJp && Force0Kerning) {
+				Sen2ExecutablePatches.PatchForce0Kerning(ms, state);
 			}
 			Sen2ExecutablePatches.PatchAddNullCheckBattleScopeCrashMaybe(ms, state);
 

--- a/SenLib/Sen2/Sen2ExecutablePatchState.cs
+++ b/SenLib/Sen2/Sen2ExecutablePatchState.cs
@@ -26,6 +26,9 @@ namespace SenLib.Sen2 {
 		// address of conditional jump statement for auto-skipping results when turbo button is held
 		public long AddressJumpBattleResultsAutoSkip { get; private set; }
 
+		// address of a conditional mov (cmovs) over setting the font kerning value to 0
+		public long AddressForce0Kerning { get; private set; }
+
 		// addresses of regions that can be repurposed for extra code space
 		public Sen2ExecutableCodeSpaceLocations CodeSpaceLocations { get; private set; }
 
@@ -55,6 +58,7 @@ namespace SenLib.Sen2 {
 				AddressJumpBattleResultsAutoSkip = 0x492bea;
 				AddressJumpBattleSomethingAutoSkip = 0x48474e;
 				AddressJumpBattleStartAutoSkip = 0x48388b;
+				AddressForce0Kerning = 0x5328e4;
 			}
 			CodeSpaceLocations = new Sen2ExecutableCodeSpaceLocations(jp);
 			BgmTimingPatchLocations = new Sen2ExecutableBgmTimingLocations(jp);

--- a/SenLib/Sen2/Sen2ExecutablePatches.cs
+++ b/SenLib/Sen2/Sen2ExecutablePatches.cs
@@ -33,5 +33,11 @@ namespace SenLib.Sen2 {
 			binary.WriteUInt40(0xe96b010000, EndianUtils.Endianness.BigEndian); // jmp
 			binary.WriteUInt8(0x90); // nop
 		}
+
+		public static void PatchForce0Kerning(Stream binary, Sen2ExecutablePatchState patchInfo) {
+			binary.Position = (long)patchInfo.Mapper.MapRamToRom((ulong)patchInfo.AddressForce0Kerning);
+			binary.WriteUInt16(0x31c0, EndianUtils.Endianness.BigEndian); // xor eax, eax
+			binary.WriteUInt8(0x90);                                      // nop
+		}
 	}
 }

--- a/SenLib/Sen2/Sen2Mods.cs
+++ b/SenLib/Sen2/Sen2Mods.cs
@@ -21,7 +21,8 @@ namespace SenLib.Sen2 {
 			bool disableMouseCapture = false,
 			bool disablePauseOnFocusLoss = false,
 			bool fixControllerMapping = false,
-			bool fixArtsSupport = false
+			bool fixArtsSupport = false,
+			bool force0Kerning = false
 		) {
 			var f = new List<FileMod>();
 			for (int i = 0; i < 2; ++i) {
@@ -36,7 +37,8 @@ namespace SenLib.Sen2 {
 					disableMouseCapture: disableMouseCapture,
 					disablePauseOnFocusLoss: disablePauseOnFocusLoss,
 					fixControllerMapping: fixControllerMapping,
-					fixArtsSupport: fixArtsSupport
+					fixArtsSupport: fixArtsSupport,
+					force0Kerning: force0Kerning
 				));
 			}
 			return f;

--- a/SenPatcherCli/Program.cs
+++ b/SenPatcherCli/Program.cs
@@ -168,7 +168,8 @@ namespace SenPatcherCli {
 					correctLanguageVoiceTables: true,
 					disableMouseCapture: true,
 					disablePauseOnFocusLoss: true,
-					fixArtsSupport: true
+					fixArtsSupport: true,
+					force0Kerning: true
 				));
 				mods.AddRange(Sen1Mods.GetAssetMods());
 				result = FileModExec.ExecuteMods(path, storage, mods, new CliProgressReporter());
@@ -184,7 +185,8 @@ namespace SenPatcherCli {
 					disableMouseCapture: true,
 					disablePauseOnFocusLoss: true,
 					fixControllerMapping: true,
-					fixArtsSupport: true
+					fixArtsSupport: true,
+					force0Kerning: true
 				));
 				mods.AddRange(Sen2Mods.GetAssetMods(Sen2Version.v142));
 				result = FileModExec.ExecuteMods(path, storage, mods, new CliProgressReporter());

--- a/SenPatcherGui/Sen1Form.Designer.cs
+++ b/SenPatcherGui/Sen1Form.Designer.cs
@@ -86,10 +86,10 @@
 			// checkBoxAllowR2InTurboMode
 			// 
 			this.checkBoxAllowR2InTurboMode.AutoSize = true;
-			this.checkBoxAllowR2InTurboMode.Location = new System.Drawing.Point(97, 260);
+			this.checkBoxAllowR2InTurboMode.Location = new System.Drawing.Point(97, 283);
 			this.checkBoxAllowR2InTurboMode.Name = "checkBoxAllowR2InTurboMode";
 			this.checkBoxAllowR2InTurboMode.Size = new System.Drawing.Size(280, 17);
-			this.checkBoxAllowR2InTurboMode.TabIndex = 11;
+			this.checkBoxAllowR2InTurboMode.TabIndex = 13;
 			this.checkBoxAllowR2InTurboMode.Text = "Enable R2 Notebook Shortcut when Turbo is enabled";
 			this.checkBoxAllowR2InTurboMode.UseVisualStyleBackColor = true;
 			// 
@@ -99,7 +99,7 @@
 			this.label4.Location = new System.Drawing.Point(94, 309);
 			this.label4.Name = "label4";
 			this.label4.Size = new System.Drawing.Size(87, 13);
-			this.label4.TabIndex = 12;
+			this.label4.TabIndex = 14;
 			this.label4.Text = "Turbo mode key:";
 			// 
 			// comboBoxTurboModeKey
@@ -109,7 +109,7 @@
 			this.comboBoxTurboModeKey.Location = new System.Drawing.Point(187, 306);
 			this.comboBoxTurboModeKey.Name = "comboBoxTurboModeKey";
 			this.comboBoxTurboModeKey.Size = new System.Drawing.Size(126, 21);
-			this.comboBoxTurboModeKey.TabIndex = 13;
+			this.comboBoxTurboModeKey.TabIndex = 15;
 			// 
 			// buttonPatch
 			// 
@@ -118,7 +118,7 @@
 			this.buttonPatch.Location = new System.Drawing.Point(12, 408);
 			this.buttonPatch.Name = "buttonPatch";
 			this.buttonPatch.Size = new System.Drawing.Size(510, 41);
-			this.buttonPatch.TabIndex = 15;
+			this.buttonPatch.TabIndex = 17;
 			this.buttonPatch.Text = "Patch!";
 			this.buttonPatch.UseVisualStyleBackColor = true;
 			this.buttonPatch.Click += new System.EventHandler(this.buttonPatch_Click);
@@ -129,7 +129,7 @@
 			this.label5.Location = new System.Drawing.Point(94, 336);
 			this.label5.Name = "label5";
 			this.label5.Size = new System.Drawing.Size(408, 52);
-			this.label5.TabIndex = 14;
+			this.label5.TabIndex = 16;
 			this.label5.Text = resources.GetString("label5.Text");
 			// 
 			// checkBoxFixHdTextureId
@@ -194,20 +194,20 @@
 			// checkBoxDisableMouseCam
 			// 
 			this.checkBoxDisableMouseCam.AutoSize = true;
-			this.checkBoxDisableMouseCam.Location = new System.Drawing.Point(97, 214);
+			this.checkBoxDisableMouseCam.Location = new System.Drawing.Point(97, 237);
 			this.checkBoxDisableMouseCam.Name = "checkBoxDisableMouseCam";
 			this.checkBoxDisableMouseCam.Size = new System.Drawing.Size(231, 17);
-			this.checkBoxDisableMouseCam.TabIndex = 9;
+			this.checkBoxDisableMouseCam.TabIndex = 11;
 			this.checkBoxDisableMouseCam.Text = "Disable Mouse Capture and Mouse Camera";
 			this.checkBoxDisableMouseCam.UseVisualStyleBackColor = true;
 			// 
 			// checkBoxDisablePauseOnFocusLoss
 			// 
 			this.checkBoxDisablePauseOnFocusLoss.AutoSize = true;
-			this.checkBoxDisablePauseOnFocusLoss.Location = new System.Drawing.Point(97, 237);
+			this.checkBoxDisablePauseOnFocusLoss.Location = new System.Drawing.Point(97, 260);
 			this.checkBoxDisablePauseOnFocusLoss.Name = "checkBoxDisablePauseOnFocusLoss";
 			this.checkBoxDisablePauseOnFocusLoss.Size = new System.Drawing.Size(219, 17);
-			this.checkBoxDisablePauseOnFocusLoss.TabIndex = 10;
+			this.checkBoxDisablePauseOnFocusLoss.TabIndex = 12;
 			this.checkBoxDisablePauseOnFocusLoss.Text = "Keep game running when in Background";
 			this.checkBoxDisablePauseOnFocusLoss.UseVisualStyleBackColor = true;
 			// 
@@ -219,18 +219,18 @@
 			this.checkBoxArtsSupport.Location = new System.Drawing.Point(97, 191);
 			this.checkBoxArtsSupport.Name = "checkBoxArtsSupport";
 			this.checkBoxArtsSupport.Size = new System.Drawing.Size(308, 17);
-			this.checkBoxArtsSupport.TabIndex = 16;
+			this.checkBoxArtsSupport.TabIndex = 9;
 			this.checkBoxArtsSupport.Text = "Fix Arts Support cut-in issues when not running at 1280x720";
 			this.checkBoxArtsSupport.UseVisualStyleBackColor = true;
 			// 
 			// checkBoxForce0Kerning
 			// 
 			this.checkBoxForce0Kerning.AutoSize = true;
-			this.checkBoxForce0Kerning.Location = new System.Drawing.Point(97, 283);
+			this.checkBoxForce0Kerning.Location = new System.Drawing.Point(97, 214);
 			this.checkBoxForce0Kerning.Name = "checkBoxForce0Kerning";
-			this.checkBoxForce0Kerning.Size = new System.Drawing.Size(376, 17);
-			this.checkBoxForce0Kerning.TabIndex = 17;
-			this.checkBoxForce0Kerning.Text = "Force nicer letter spacing (works with vanilla or Cuprum HD Font mod only)";
+			this.checkBoxForce0Kerning.Size = new System.Drawing.Size(396, 17);
+			this.checkBoxForce0Kerning.TabIndex = 10;
+			this.checkBoxForce0Kerning.Text = "Adjust font spacing for use with HD Cuprum font from CS3 or HD Texture Pack";
 			this.checkBoxForce0Kerning.UseVisualStyleBackColor = true;
 			// 
 			// Sen1Form

--- a/SenPatcherGui/Sen1Form.Designer.cs
+++ b/SenPatcherGui/Sen1Form.Designer.cs
@@ -41,6 +41,7 @@
 			this.checkBoxDisableMouseCam = new System.Windows.Forms.CheckBox();
 			this.checkBoxDisablePauseOnFocusLoss = new System.Windows.Forms.CheckBox();
 			this.checkBoxArtsSupport = new System.Windows.Forms.CheckBox();
+			this.checkBoxForce0Kerning = new System.Windows.Forms.CheckBox();
 			this.SuspendLayout();
 			// 
 			// label1
@@ -95,7 +96,7 @@
 			// label4
 			// 
 			this.label4.AutoSize = true;
-			this.label4.Location = new System.Drawing.Point(94, 286);
+			this.label4.Location = new System.Drawing.Point(94, 309);
 			this.label4.Name = "label4";
 			this.label4.Size = new System.Drawing.Size(87, 13);
 			this.label4.TabIndex = 12;
@@ -105,7 +106,7 @@
 			// 
 			this.comboBoxTurboModeKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.comboBoxTurboModeKey.FormattingEnabled = true;
-			this.comboBoxTurboModeKey.Location = new System.Drawing.Point(187, 283);
+			this.comboBoxTurboModeKey.Location = new System.Drawing.Point(187, 306);
 			this.comboBoxTurboModeKey.Name = "comboBoxTurboModeKey";
 			this.comboBoxTurboModeKey.Size = new System.Drawing.Size(126, 21);
 			this.comboBoxTurboModeKey.TabIndex = 13;
@@ -114,7 +115,7 @@
 			// 
 			this.buttonPatch.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.buttonPatch.Location = new System.Drawing.Point(12, 385);
+			this.buttonPatch.Location = new System.Drawing.Point(12, 408);
 			this.buttonPatch.Name = "buttonPatch";
 			this.buttonPatch.Size = new System.Drawing.Size(510, 41);
 			this.buttonPatch.TabIndex = 15;
@@ -125,7 +126,7 @@
 			// label5
 			// 
 			this.label5.AutoSize = true;
-			this.label5.Location = new System.Drawing.Point(94, 313);
+			this.label5.Location = new System.Drawing.Point(94, 336);
 			this.label5.Name = "label5";
 			this.label5.Size = new System.Drawing.Size(408, 52);
 			this.label5.TabIndex = 14;
@@ -222,11 +223,22 @@
 			this.checkBoxArtsSupport.Text = "Fix Arts Support cut-in issues when not running at 1280x720";
 			this.checkBoxArtsSupport.UseVisualStyleBackColor = true;
 			// 
+			// checkBoxForce0Kerning
+			// 
+			this.checkBoxForce0Kerning.AutoSize = true;
+			this.checkBoxForce0Kerning.Location = new System.Drawing.Point(97, 283);
+			this.checkBoxForce0Kerning.Name = "checkBoxForce0Kerning";
+			this.checkBoxForce0Kerning.Size = new System.Drawing.Size(376, 17);
+			this.checkBoxForce0Kerning.TabIndex = 17;
+			this.checkBoxForce0Kerning.Text = "Force nicer letter spacing (works with vanilla or Cuprum HD Font mod only)";
+			this.checkBoxForce0Kerning.UseVisualStyleBackColor = true;
+			// 
 			// Sen1Form
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(534, 438);
+			this.ClientSize = new System.Drawing.Size(534, 461);
+			this.Controls.Add(this.checkBoxForce0Kerning);
 			this.Controls.Add(this.checkBoxArtsSupport);
 			this.Controls.Add(this.checkBoxDisablePauseOnFocusLoss);
 			this.Controls.Add(this.checkBoxDisableMouseCam);
@@ -270,5 +282,6 @@
 		private System.Windows.Forms.CheckBox checkBoxDisableMouseCam;
 		private System.Windows.Forms.CheckBox checkBoxDisablePauseOnFocusLoss;
 		private System.Windows.Forms.CheckBox checkBoxArtsSupport;
+		private System.Windows.Forms.CheckBox checkBoxForce0Kerning;
 	}
 }

--- a/SenPatcherGui/Sen1Form.cs
+++ b/SenPatcherGui/Sen1Form.cs
@@ -60,6 +60,7 @@ namespace SenPatcherGui {
 				bool disableMouseCapture = checkBoxDisableMouseCam.Checked;
 				bool disablePauseOnFocusLoss = checkBoxDisablePauseOnFocusLoss.Checked;
 				bool fixArtsSupport = checkBoxArtsSupport.Checked;
+				bool force0Kerning = checkBoxForce0Kerning.Checked;
 
 				var mods = new List<FileMod>();
 				mods.AddRange(Sen1Mods.GetExecutableMods(
@@ -70,7 +71,8 @@ namespace SenPatcherGui {
 					correctLanguageVoiceTables: fixVoiceTables,
 					disableMouseCapture: disableMouseCapture,
 					disablePauseOnFocusLoss: disablePauseOnFocusLoss,
-					fixArtsSupport: fixArtsSupport
+					fixArtsSupport: fixArtsSupport,
+					force0Kerning: force0Kerning
 				));
 				if (patchAssets) {
 					mods.AddRange(Sen1Mods.GetAssetMods());

--- a/SenPatcherGui/Sen2Form.Designer.cs
+++ b/SenPatcherGui/Sen2Form.Designer.cs
@@ -99,7 +99,7 @@
 			this.buttonPatch.Location = new System.Drawing.Point(12, 402);
 			this.buttonPatch.Name = "buttonPatch";
 			this.buttonPatch.Size = new System.Drawing.Size(510, 41);
-			this.buttonPatch.TabIndex = 14;
+			this.buttonPatch.TabIndex = 17;
 			this.buttonPatch.Text = "Patch!";
 			this.buttonPatch.UseVisualStyleBackColor = true;
 			this.buttonPatch.Click += new System.EventHandler(this.buttonPatch_Click);
@@ -188,20 +188,20 @@
 			// checkBoxDisableMouseCam
 			// 
 			this.checkBoxDisableMouseCam.AutoSize = true;
-			this.checkBoxDisableMouseCam.Location = new System.Drawing.Point(97, 326);
+			this.checkBoxDisableMouseCam.Location = new System.Drawing.Point(97, 349);
 			this.checkBoxDisableMouseCam.Name = "checkBoxDisableMouseCam";
 			this.checkBoxDisableMouseCam.Size = new System.Drawing.Size(231, 17);
-			this.checkBoxDisableMouseCam.TabIndex = 12;
+			this.checkBoxDisableMouseCam.TabIndex = 15;
 			this.checkBoxDisableMouseCam.Text = "Disable Mouse Capture and Mouse Camera";
 			this.checkBoxDisableMouseCam.UseVisualStyleBackColor = true;
 			// 
 			// checkBoxDisablePauseOnFocusLoss
 			// 
 			this.checkBoxDisablePauseOnFocusLoss.AutoSize = true;
-			this.checkBoxDisablePauseOnFocusLoss.Location = new System.Drawing.Point(97, 349);
+			this.checkBoxDisablePauseOnFocusLoss.Location = new System.Drawing.Point(97, 372);
 			this.checkBoxDisablePauseOnFocusLoss.Name = "checkBoxDisablePauseOnFocusLoss";
 			this.checkBoxDisablePauseOnFocusLoss.Size = new System.Drawing.Size(219, 17);
-			this.checkBoxDisablePauseOnFocusLoss.TabIndex = 13;
+			this.checkBoxDisablePauseOnFocusLoss.TabIndex = 16;
 			this.checkBoxDisablePauseOnFocusLoss.Text = "Keep game running when in Background";
 			this.checkBoxDisablePauseOnFocusLoss.UseVisualStyleBackColor = true;
 			// 
@@ -213,7 +213,7 @@
 			this.checkBoxControllerMapping.Location = new System.Drawing.Point(97, 280);
 			this.checkBoxControllerMapping.Name = "checkBoxControllerMapping";
 			this.checkBoxControllerMapping.Size = new System.Drawing.Size(409, 17);
-			this.checkBoxControllerMapping.TabIndex = 15;
+			this.checkBoxControllerMapping.TabIndex = 12;
 			this.checkBoxControllerMapping.Text = "Fix inconsistent Controller Button Prompts and Mappings when remapping buttons";
 			this.checkBoxControllerMapping.UseVisualStyleBackColor = true;
 			// 
@@ -225,18 +225,18 @@
 			this.checkBoxArtsSupport.Location = new System.Drawing.Point(97, 303);
 			this.checkBoxArtsSupport.Name = "checkBoxArtsSupport";
 			this.checkBoxArtsSupport.Size = new System.Drawing.Size(228, 17);
-			this.checkBoxArtsSupport.TabIndex = 16;
+			this.checkBoxArtsSupport.TabIndex = 13;
 			this.checkBoxArtsSupport.Text = "Fix invisible character in Arts Support cut-in";
 			this.checkBoxArtsSupport.UseVisualStyleBackColor = true;
 			// 
 			// checkBoxForce0Kerning
 			// 
 			this.checkBoxForce0Kerning.AutoSize = true;
-			this.checkBoxForce0Kerning.Location = new System.Drawing.Point(97, 372);
+			this.checkBoxForce0Kerning.Location = new System.Drawing.Point(97, 326);
 			this.checkBoxForce0Kerning.Name = "checkBoxForce0Kerning";
-			this.checkBoxForce0Kerning.Size = new System.Drawing.Size(376, 17);
-			this.checkBoxForce0Kerning.TabIndex = 17;
-			this.checkBoxForce0Kerning.Text = "Force nicer letter spacing (works with vanilla or Cuprum HD Font mod only)";
+			this.checkBoxForce0Kerning.Size = new System.Drawing.Size(396, 17);
+			this.checkBoxForce0Kerning.TabIndex = 14;
+			this.checkBoxForce0Kerning.Text = "Adjust font spacing for use with HD Cuprum font from CS3 or HD Texture Pack";
 			this.checkBoxForce0Kerning.UseVisualStyleBackColor = true;
 			// 
 			// Sen2Form

--- a/SenPatcherGui/Sen2Form.Designer.cs
+++ b/SenPatcherGui/Sen2Form.Designer.cs
@@ -40,6 +40,7 @@
 			this.checkBoxDisablePauseOnFocusLoss = new System.Windows.Forms.CheckBox();
 			this.checkBoxControllerMapping = new System.Windows.Forms.CheckBox();
 			this.checkBoxArtsSupport = new System.Windows.Forms.CheckBox();
+			this.checkBoxForce0Kerning = new System.Windows.Forms.CheckBox();
 			this.SuspendLayout();
 			// 
 			// label5
@@ -95,7 +96,7 @@
 			// 
 			this.buttonPatch.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.buttonPatch.Location = new System.Drawing.Point(12, 379);
+			this.buttonPatch.Location = new System.Drawing.Point(12, 402);
 			this.buttonPatch.Name = "buttonPatch";
 			this.buttonPatch.Size = new System.Drawing.Size(510, 41);
 			this.buttonPatch.TabIndex = 14;
@@ -228,11 +229,22 @@
 			this.checkBoxArtsSupport.Text = "Fix invisible character in Arts Support cut-in";
 			this.checkBoxArtsSupport.UseVisualStyleBackColor = true;
 			// 
+			// checkBoxForce0Kerning
+			// 
+			this.checkBoxForce0Kerning.AutoSize = true;
+			this.checkBoxForce0Kerning.Location = new System.Drawing.Point(97, 372);
+			this.checkBoxForce0Kerning.Name = "checkBoxForce0Kerning";
+			this.checkBoxForce0Kerning.Size = new System.Drawing.Size(376, 17);
+			this.checkBoxForce0Kerning.TabIndex = 17;
+			this.checkBoxForce0Kerning.Text = "Force nicer letter spacing (works with vanilla or Cuprum HD Font mod only)";
+			this.checkBoxForce0Kerning.UseVisualStyleBackColor = true;
+			// 
 			// Sen2Form
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(534, 432);
+			this.ClientSize = new System.Drawing.Size(534, 455);
+			this.Controls.Add(this.checkBoxForce0Kerning);
 			this.Controls.Add(this.checkBoxArtsSupport);
 			this.Controls.Add(this.checkBoxControllerMapping);
 			this.Controls.Add(this.checkBoxDisablePauseOnFocusLoss);
@@ -276,5 +288,6 @@
 		private System.Windows.Forms.CheckBox checkBoxDisablePauseOnFocusLoss;
 		private System.Windows.Forms.CheckBox checkBoxControllerMapping;
 		private System.Windows.Forms.CheckBox checkBoxArtsSupport;
+		private System.Windows.Forms.CheckBox checkBoxForce0Kerning;
 	}
 }

--- a/SenPatcherGui/Sen2Form.cs
+++ b/SenPatcherGui/Sen2Form.cs
@@ -42,6 +42,7 @@ namespace SenPatcherGui {
 				bool disablePauseOnFocusLoss = checkBoxDisablePauseOnFocusLoss.Checked;
 				bool fixArtsSupport = checkBoxArtsSupport.Checked;
 				bool fixControllerMapping = checkBoxControllerMapping.Checked;
+				bool force0Kerning = checkBoxForce0Kerning.Checked;
 
 				var mods = new List<FileMod>();
 				mods.AddRange(Sen2Mods.GetExecutableMods(
@@ -54,7 +55,8 @@ namespace SenPatcherGui {
 					disableMouseCapture: disableMouseCapture,
 					disablePauseOnFocusLoss: disablePauseOnFocusLoss,
 					fixControllerMapping: fixControllerMapping,
-					fixArtsSupport: fixArtsSupport
+					fixArtsSupport: fixArtsSupport,
+					force0Kerning: force0Kerning
 				));
 				if (patchAssets) {
 					mods.AddRange(Sen2Mods.GetAssetMods(Sen2Version.v142));


### PR DESCRIPTION
This new option forces some kind of font kerning value to 0 always instead of 80 on Cold Steel 1 and 2. This makes the font look a lot much nicer to the eyes, reminiscent of how the font looks in Cold Steel 3 and 4.

This only works with either the vanilla font or the Cuprum HD Font, not with the vanilla HD font (the one that's not Cuprum), this is noted on the checkbox.

Credits to @masagrator for finding this on the Switch version of the games.

A few examples of how this looks like:
![ed8_zdBZIXuKHT](https://user-images.githubusercontent.com/18301034/168818471-475ac5bb-2ce4-445b-a173-8d756d078ca9.jpg)
![ed8_2_PC_US_SnUcBA4Jbc](https://user-images.githubusercontent.com/18301034/168818519-0e31f47c-ce17-4703-80a5-d3c7b0a8b1f5.png)
![ed8_FC4mSv6zd1](https://user-images.githubusercontent.com/18301034/168818536-1e0a4050-23e5-4052-9540-66847048f9bc.jpg)
![ed8_7AhAyHbqIO](https://user-images.githubusercontent.com/18301034/168818558-0ba36c3d-e071-417b-85cc-3e2ea0659d31.jpg)
![ed8_3OhbfqpgLS](https://user-images.githubusercontent.com/18301034/168818570-2b193735-0ecc-4b4a-a28b-b8918d3cf1e8.jpg)

